### PR TITLE
0.2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val commonSettings = Seq(
   organization := "com.github.fomkin",
-  version := "0.2.9",
+  version := "0.2.10",
   scalaVersion := "2.11.7",
   scalacOptions ++= Seq(
     "-deprecation",
@@ -28,7 +28,7 @@ val `scala-reql-pushka` = crossProject.crossType(CrossType.Pure).
   dependsOn(`scala-reql-core`).
   settings(commonSettings:_*).
   settings(
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     libraryDependencies += "com.github.fomkin" %%% "pushka-json" % "0.4.1"
   )
 
@@ -40,7 +40,7 @@ lazy val `scala-reql-akka` = project.
   settings(commonSettings:_*).
   settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor" % "2.3.7"
+      "com.typesafe.akka" %% "akka-actor" % "2.4.2"
     )
   )
 

--- a/project/ApiDefinitions.scala
+++ b/project/ApiDefinitions.scala
@@ -446,6 +446,16 @@ object ApiDefinitions {
       fun(Top.Sequence)(arg("f", Top.FunctionArg(1)))
     ),
 
+    //SET_UNION = 90; // ARRAY, ARRAY -> ARRAY
+    module(termType = 90, name = "setUnion")(Top.Arr)(
+      fun(Top.Arr)(arg("x", Top.Arr))
+    ),
+
+    //SET_DIFFERENCE = 91; // ARRAY, ARRAY -> ARRAY
+    module(termType = 91, name = "setDifference")(Top.Arr)(
+      fun(Top.Arr)(arg("x", Top.Arr))
+    ),
+
     // Deletes all the rows in a selection.
     //DELETE   = 54; // StreamSelection, {durability:STRING, return_changes:BOOL} -> OBJECT | SingleSelection -> OBJECT
     module(termType = 54, name = "delete")(Top.Datum.Obj)(


### PR DESCRIPTION
- New version of Akka
- Release version of macro paradise, instead of milestone version.
- Add `setUnion` and `setDifference` methods.
- Remove unnecessary check in cursor handler.
